### PR TITLE
[Refactor/#17/webrtc migration] MVI 패턴으로의 마이그레이션 및 캠 화면 디자인에 맞게 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
 
     // 바텀네비 종속성
     implementation("androidx.navigation:navigation-compose:2.7.4")
+    implementation ("androidx.graphics:graphics-shapes:1.0.0-rc01")
 
 
     // Import the Firebase BoM

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.SaybetterEducator"
-        android:name=".config.SayBetterApplication"
+        android:name=".di.SayBetterApplication"
         tools:targetApi="31">
 
         <provider
@@ -65,7 +65,7 @@
 
         <!-- 시그널링 서버와 지속적으로 데이터를 주고받아야 하므로 DataSync type으로 명시 -->
         <service
-            android:name=".utils.webrtc.service.MainService"
+            android:name=".data.service.MainService"
             android:foregroundServiceType="dataSync"/>
     </application>
 </manifest>

--- a/app/src/main/java/com/example/saybettereducator/data/api/helper/FirebaseClient.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/api/helper/FirebaseClient.kt
@@ -1,8 +1,8 @@
 package com.example.saybettereducator.data.api.helper
 
 import android.util.Log
-import com.example.saybettereducator.domain.model.DataModel
-import com.example.saybettereducator.domain.model.UserStatus
+import com.example.saybettereducator.data.model.DataModel
+import com.example.saybettereducator.data.model.UserStatus
 import com.example.saybettereducator.data.model.FirebaseFieldNames.LATEST_EVENT
 import com.example.saybettereducator.data.model.FirebaseFieldNames.STATUS
 import com.example.saybettereducator.utils.MyEventListener

--- a/app/src/main/java/com/example/saybettereducator/data/api/helper/FirebaseClient.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/api/helper/FirebaseClient.kt
@@ -1,10 +1,10 @@
-package com.example.saybettereducator.utils.webrtc.firebaseClient
+package com.example.saybettereducator.data.api.helper
 
 import android.util.Log
 import com.example.saybettereducator.domain.model.DataModel
 import com.example.saybettereducator.domain.model.UserStatus
-import com.example.saybettereducator.utils.FirebaseFieldNames.LATEST_EVENT
-import com.example.saybettereducator.utils.FirebaseFieldNames.STATUS
+import com.example.saybettereducator.data.model.FirebaseFieldNames.LATEST_EVENT
+import com.example.saybettereducator.data.model.FirebaseFieldNames.STATUS
 import com.example.saybettereducator.utils.MyEventListener
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseReference

--- a/app/src/main/java/com/example/saybettereducator/data/api/helper/WebRTCClient.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/api/helper/WebRTCClient.kt
@@ -1,8 +1,8 @@
 package com.example.saybettereducator.data.api.helper
 
 import android.content.Context
-import com.example.saybettereducator.domain.model.DataModel
-import com.example.saybettereducator.domain.model.DataModelType
+import com.example.saybettereducator.data.model.DataModel
+import com.example.saybettereducator.data.model.DataModelType
 import com.example.saybettereducator.utils.webrtcObserver.MySdpObserver
 import com.google.gson.Gson
 import org.webrtc.AudioTrack

--- a/app/src/main/java/com/example/saybettereducator/data/api/helper/WebRTCClient.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/api/helper/WebRTCClient.kt
@@ -1,6 +1,7 @@
 package com.example.saybettereducator.data.api.helper
 
 import android.content.Context
+import android.graphics.PixelFormat
 import com.example.saybettereducator.data.model.DataModel
 import com.example.saybettereducator.data.model.DataModelType
 import com.example.saybettereducator.utils.webrtcObserver.MySdpObserver
@@ -210,11 +211,8 @@ class WebRTCClient @Inject constructor(
         view.run {
             setMirror(false)
             setEnableHardwareScaler(true)
+//            holder.setFormat(PixelFormat.TRANSPARENT)
             init(eglBaseContext, null)
-
-//            val params: ViewGroup.LayoutParams = view.layoutParams
-//            params.width = 328
-//            params.height = 196
         }
     }
     fun initRemoteSurfaceView(view : SurfaceViewRenderer) {

--- a/app/src/main/java/com/example/saybettereducator/data/api/helper/WebRTCClient.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/api/helper/WebRTCClient.kt
@@ -1,8 +1,9 @@
-package com.example.saybettereducator.utils.webrtc.webrtcClient
+package com.example.saybettereducator.data.api.helper
 
 import android.content.Context
 import com.example.saybettereducator.domain.model.DataModel
 import com.example.saybettereducator.domain.model.DataModelType
+import com.example.saybettereducator.utils.webrtcObserver.MySdpObserver
 import com.google.gson.Gson
 import org.webrtc.AudioTrack
 import org.webrtc.Camera2Enumerator

--- a/app/src/main/java/com/example/saybettereducator/data/model/DataModel.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/model/DataModel.kt
@@ -1,4 +1,4 @@
-package com.example.saybettereducator.domain.model
+package com.example.saybettereducator.data.model
 
 enum class DataModelType {
     StartAudioCall, StartVideoCall, Offer, Answer, IceCandidates, EndCall

--- a/app/src/main/java/com/example/saybettereducator/data/model/FirebaseFieldNames.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/model/FirebaseFieldNames.kt
@@ -1,4 +1,4 @@
-package com.example.saybettereducator.utils
+package com.example.saybettereducator.data.model
 
 object FirebaseFieldNames {
     const val STATUS = "status"

--- a/app/src/main/java/com/example/saybettereducator/data/model/MainServiceActions.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/model/MainServiceActions.kt
@@ -1,4 +1,4 @@
-package com.example.saybettereducator.utils.webrtc.service
+package com.example.saybettereducator.data.model
 
 enum class MainServiceActions {
     START_SERVICE, SETUP_VIEWS, END_CALL, SWITCH_CAMERA, TOGGLE_AUDIO, TOGGLE_VIDEO;

--- a/app/src/main/java/com/example/saybettereducator/data/model/UserStatus.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/model/UserStatus.kt
@@ -1,4 +1,4 @@
-package com.example.saybettereducator.domain.model
+package com.example.saybettereducator.data.model
 
 enum class UserStatus {
     ONLINE, OFFLINE, IN_CALL

--- a/app/src/main/java/com/example/saybettereducator/data/repository/MainRepository.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/repository/MainRepository.kt
@@ -1,11 +1,11 @@
-package com.example.saybettereducator.utils.webrtc.repository
+package com.example.saybettereducator.data.repository
 
 import com.example.saybettereducator.domain.model.DataModel
 import com.example.saybettereducator.domain.model.DataModelType.*
 import com.example.saybettereducator.domain.model.UserStatus
-import com.example.saybettereducator.utils.webrtc.firebaseClient.FirebaseClient
-import com.example.saybettereducator.utils.webrtc.webrtcClient.MyPeerObserver
-import com.example.saybettereducator.utils.webrtc.webrtcClient.WebRTCClient
+import com.example.saybettereducator.data.api.helper.FirebaseClient
+import com.example.saybettereducator.utils.webrtcObserver.MyPeerObserver
+import com.example.saybettereducator.data.api.helper.WebRTCClient
 import com.google.gson.Gson
 import org.webrtc.IceCandidate
 import org.webrtc.MediaStream

--- a/app/src/main/java/com/example/saybettereducator/data/repository/MainRepository.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/repository/MainRepository.kt
@@ -1,8 +1,8 @@
 package com.example.saybettereducator.data.repository
 
-import com.example.saybettereducator.domain.model.DataModel
-import com.example.saybettereducator.domain.model.DataModelType.*
-import com.example.saybettereducator.domain.model.UserStatus
+import com.example.saybettereducator.data.model.DataModel
+import com.example.saybettereducator.data.model.DataModelType.*
+import com.example.saybettereducator.data.model.UserStatus
 import com.example.saybettereducator.data.api.helper.FirebaseClient
 import com.example.saybettereducator.utils.webrtcObserver.MyPeerObserver
 import com.example.saybettereducator.data.api.helper.WebRTCClient

--- a/app/src/main/java/com/example/saybettereducator/data/repository/MainRepository.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/repository/MainRepository.kt
@@ -6,6 +6,7 @@ import com.example.saybettereducator.data.model.UserStatus
 import com.example.saybettereducator.data.api.helper.FirebaseClient
 import com.example.saybettereducator.utils.webrtcObserver.MyPeerObserver
 import com.example.saybettereducator.data.api.helper.WebRTCClient
+import com.example.saybettereducator.ui.activity.VideoCallActivity
 import com.google.gson.Gson
 import org.webrtc.IceCandidate
 import org.webrtc.MediaStream
@@ -22,6 +23,7 @@ class MainRepository @Inject constructor(
     private val gson : Gson
 ) : WebRTCClient.Listener {
     var listener : Listener? = null
+    var connectionListener : ConnectionListener? = null
     private var target : String? = null
     private var remoteView: SurfaceViewRenderer? = null
 
@@ -101,11 +103,16 @@ class MainRepository @Inject constructor(
 
             override fun onConnectionChange(newState: PeerConnection.PeerConnectionState?) {
                 super.onConnectionChange(newState)
+
+                // Peer 간 연결되었을 때!!
                 if(newState == PeerConnection.PeerConnectionState.CONNECTED) {
                     // 1. change my status to in call
                     changeMyStatus(UserStatus.IN_CALL)
                     // 2. clear latest event inside my user section in firebase database
                     firebaseClient.clearLatestEvent()
+
+                    // 3. 이벤트 보내기 (VideoCallViewModel에 구현)
+                    connectionListener?.onPeerConnectionReady()
                 }
             }
         })
@@ -136,6 +143,10 @@ class MainRepository @Inject constructor(
     interface Listener {
         fun onLatestEventReceived(data : DataModel)
         fun endCall()
+    }
+
+    interface ConnectionListener {
+        fun onPeerConnectionReady()
     }
 
     override fun onTransferEventToSocket(data: DataModel) {

--- a/app/src/main/java/com/example/saybettereducator/data/repository/MainServiceRepository.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/repository/MainServiceRepository.kt
@@ -1,9 +1,11 @@
-package com.example.saybettereducator.utils.webrtc.service
+package com.example.saybettereducator.data.repository
 
 import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.annotation.RequiresApi
+import com.example.saybettereducator.data.model.MainServiceActions
+import com.example.saybettereducator.data.service.MainService
 import javax.inject.Inject
 
 class MainServiceRepository @Inject constructor(

--- a/app/src/main/java/com/example/saybettereducator/data/service/MainService.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/service/MainService.kt
@@ -1,4 +1,4 @@
-package com.example.saybettereducator.utils.webrtc.service
+package com.example.saybettereducator.data.service
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -10,8 +10,8 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import com.example.saybettereducator.domain.model.DataModel
-import com.example.saybettereducator.utils.webrtc.repository.MainRepository
-import com.example.saybettereducator.utils.webrtc.service.MainServiceActions.*
+import com.example.saybettereducator.data.repository.MainRepository
+import com.example.saybettereducator.data.model.MainServiceActions.*
 import dagger.hilt.android.AndroidEntryPoint
 import org.webrtc.SurfaceViewRenderer
 import javax.inject.Inject

--- a/app/src/main/java/com/example/saybettereducator/data/service/MainService.kt
+++ b/app/src/main/java/com/example/saybettereducator/data/service/MainService.kt
@@ -9,7 +9,7 @@ import android.os.IBinder
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
-import com.example.saybettereducator.domain.model.DataModel
+import com.example.saybettereducator.data.model.DataModel
 import com.example.saybettereducator.data.repository.MainRepository
 import com.example.saybettereducator.data.model.MainServiceActions.*
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/com/example/saybettereducator/di/SayBetterAppModule.kt
+++ b/app/src/main/java/com/example/saybettereducator/di/SayBetterAppModule.kt
@@ -1,4 +1,4 @@
-package com.example.saybettereducator.utils.module
+package com.example.saybettereducator.di
 
 import android.content.Context
 import com.google.firebase.database.DatabaseReference
@@ -12,7 +12,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-class AppModule {
+class SayBetterAppModule {
 
     @Provides
     fun provideDataBaseInstance() : FirebaseDatabase = FirebaseDatabase.getInstance()

--- a/app/src/main/java/com/example/saybettereducator/di/SayBetterApplication.kt
+++ b/app/src/main/java/com/example/saybettereducator/di/SayBetterApplication.kt
@@ -1,4 +1,4 @@
-package com.example.saybettereducator.config
+package com.example.saybettereducator.di
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp

--- a/app/src/main/java/com/example/saybettereducator/ui/activity/LoginActivity.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/activity/LoginActivity.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.unit.sp
 import com.example.saybettereducator.R
 import com.example.saybettereducator.ui.theme.MainGreen
 import com.example.saybettereducator.ui.theme.pretendardMediumFont
-import com.example.saybettereducator.utils.webrtc.repository.MainRepository
+import com.example.saybettereducator.data.repository.MainRepository
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/app/src/main/java/com/example/saybettereducator/ui/activity/MaActivity.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/activity/MaActivity.kt
@@ -55,9 +55,9 @@ import com.example.saybettereducator.ui.theme.MainGreen
 import com.example.saybettereducator.ui.theme.montserratFont
 import com.example.saybettereducator.ui.theme.pretendardMediumFont
 import com.example.saybettereducator.utils.permission.checkAndRequestPermissions
-import com.example.saybettereducator.utils.webrtc.repository.MainRepository
-import com.example.saybettereducator.utils.webrtc.service.MainService
-import com.example.saybettereducator.utils.webrtc.service.MainServiceRepository
+import com.example.saybettereducator.data.repository.MainRepository
+import com.example.saybettereducator.data.service.MainService
+import com.example.saybettereducator.data.repository.MainServiceRepository
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/app/src/main/java/com/example/saybettereducator/ui/activity/MaActivity.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/activity/MaActivity.kt
@@ -46,7 +46,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.saybettereducator.R
 import com.example.saybettereducator.data.model.DataModel
-import com.example.saybettereducator.ui.view.screen.CalendarScreen
+import com.example.saybettereducator.ui.view.CalendarScreen
 import com.example.saybettereducator.ui.view.HomeScreen
 import com.example.saybettereducator.ui.view.LearnerScreen
 import com.example.saybettereducator.ui.view.SolutionScreen

--- a/app/src/main/java/com/example/saybettereducator/ui/activity/MaActivity.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/activity/MaActivity.kt
@@ -45,7 +45,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.saybettereducator.R
-import com.example.saybettereducator.domain.model.DataModel
+import com.example.saybettereducator.data.model.DataModel
 import com.example.saybettereducator.ui.view.screen.CalendarScreen
 import com.example.saybettereducator.ui.view.HomeScreen
 import com.example.saybettereducator.ui.view.LearnerScreen

--- a/app/src/main/java/com/example/saybettereducator/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/activity/MainActivity.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
-import com.example.saybettereducator.domain.model.DataModel
+import com.example.saybettereducator.data.model.DataModel
 import com.example.saybettereducator.ui.components.MainBottomNavigationBar
 import com.example.saybettereducator.ui.navigation.AppNavHost
 import com.example.saybettereducator.ui.theme.SaybetterEducatorTheme

--- a/app/src/main/java/com/example/saybettereducator/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/activity/MainActivity.kt
@@ -23,9 +23,9 @@ import com.example.saybettereducator.ui.components.MainBottomNavigationBar
 import com.example.saybettereducator.ui.navigation.AppNavHost
 import com.example.saybettereducator.ui.theme.SaybetterEducatorTheme
 import com.example.saybettereducator.ui.components.main.MainTopBar
-import com.example.saybettereducator.utils.webrtc.repository.MainRepository
-import com.example.saybettereducator.utils.webrtc.service.MainService
-import com.example.saybettereducator.utils.webrtc.service.MainServiceRepository
+import com.example.saybettereducator.data.repository.MainRepository
+import com.example.saybettereducator.data.service.MainService
+import com.example.saybettereducator.data.repository.MainServiceRepository
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/app/src/main/java/com/example/saybettereducator/ui/activity/VideoCallActivity.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/activity/VideoCallActivity.kt
@@ -2,6 +2,7 @@ package com.example.saybettereducator.ui.activity
 
 import android.os.Build
 import android.os.Bundle
+import android.provider.MediaStore.Video
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.annotation.RequiresApi
@@ -38,13 +39,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asComposePath
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.zIndex
+import androidx.graphics.shapes.RoundedPolygon
+import androidx.graphics.shapes.toPath
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.saybettereducator.R
 import com.example.saybettereducator.ui.theme.DarkGray
 import com.example.saybettereducator.ui.theme.DeepDarkGray
@@ -54,7 +62,12 @@ import com.example.saybettereducator.utils.customClick.CustomClickEvent
 import com.example.saybettereducator.data.service.MainService
 import com.example.saybettereducator.data.repository.MainServiceRepository
 import com.example.saybettereducator.data.api.helper.WebRTCClient
+import com.example.saybettereducator.ui.intent.VideoCallIntent
+import com.example.saybettereducator.ui.sideeffect.VideoCallSideEffect
+import com.example.saybettereducator.ui.viewmodel.VideoCallViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 import org.webrtc.SurfaceViewRenderer
 import javax.inject.Inject
 
@@ -112,29 +125,33 @@ class VideoCallActivity: ComponentActivity(), MainService.EndCallListener {
             finish()
         }
 
-        isCaller = intent.getBooleanExtra("isCaller", true)
-
         // MainService에서 SurfaceView를 관리하도록 위임
         MainService.localSurfaceView = SurfaceViewRenderer(this)
         MainService.remoteSurfaceView = SurfaceViewRenderer(this)
+
+        isCaller = intent.getBooleanExtra("isCaller", true)
 
         // Activity에 표시될 SurfaceViewRenderer를 MainService 멤버변수에 연결하고 serviceRepo를 통해 초기화하도록 명령
         serviceRepository.setupViews(isCaller, target!!)
 
         MainService.endCallListener = this
-
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
-    fun VideoCallView(
-
-    ) {
+    fun VideoCallView(viewModel: VideoCallViewModel = hiltViewModel()) {
         var isStart by remember { mutableStateOf(false) }
         val isCameraOn by remember {
-            mutableStateOf(true)
+            mutableStateOf(false)
         }
+        val viewState by viewModel.collectAsState()
+        viewModel.collectSideEffect {
+            when(it) {
+                is VideoCallSideEffect.PeerConnectionSuccess -> viewModel.handleIntent(VideoCallIntent.OnRemoteViewReady)
+            }
+        }
+
 
         Scaffold(
             topBar = {
@@ -187,38 +204,43 @@ class VideoCallActivity: ComponentActivity(), MainService.EndCallListener {
                         .padding(innerPadding)
                         .fillMaxSize()
                 ) {
-                    if(isCameraOn /*&& webRTCClient.isLocalViewInit*/){
+                    // educator cam
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .padding(top = 53.dp)
+                            .size(width = 328.dp, height = 196.dp)
+                            .background(
+                                color = Color.DarkGray,
+                                shape = RoundedCornerShape(16.dp)
+                            )
+                    ) {
                         LocalVideoRenderer(
                             modifier = Modifier
                                 .size(width = 328.dp, height = 196.dp)
                                 .clip(RoundedCornerShape(16.dp))
                         )
-                    } else {
-                        Image(
-                            painter = painterResource(id = R.drawable.educator_cam),
-                            contentDescription = "교육자 캠",
-                            modifier = Modifier
-                                .size(width = 328.dp, height = 196.dp)
-                        )
                     }
 
 
-                    if(isCameraOn /*&& webRTCClient.isRemoteViewInit*/) {
-                        RemoteVideoRenderer(
-                            modifier = Modifier
-                                .padding(top = 12.dp)
-                                .size(width = 328.dp, height = 196.dp)
-                                .clip(RoundedCornerShape(16.dp))
-                        )
-                    } else {
-                        Image(
-                            painter = painterResource(id = R.drawable.learner_cam),
-                            contentDescription = "학습자 캠",
-                            modifier = Modifier
-                                .padding(top = 12.dp)
-                                .size(width = 328.dp, height = 196.dp)
-
-                        )
+                    // learner cam
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .padding(top = 12.dp)
+                            .size(width = 328.dp, height = 196.dp)
+                            .background(
+                                color = Color.DarkGray,
+                                shape = RoundedCornerShape(16.dp)
+                            )
+                    ) {
+                        if (viewState.isPeerConnected){
+                            RemoteVideoRenderer(
+                                modifier = Modifier
+                                    .size(width = 328.dp, height = 196.dp)
+                                    .clip(RoundedCornerShape(16.dp))
+                            )
+                        }
                     }
 
 

--- a/app/src/main/java/com/example/saybettereducator/ui/activity/VideoCallActivity.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/activity/VideoCallActivity.kt
@@ -51,9 +51,9 @@ import com.example.saybettereducator.ui.theme.DeepDarkGray
 import com.example.saybettereducator.ui.theme.MainGreen
 import com.example.saybettereducator.ui.theme.pretendardMediumFont
 import com.example.saybettereducator.utils.customClick.CustomClickEvent
-import com.example.saybettereducator.utils.webrtc.service.MainService
-import com.example.saybettereducator.utils.webrtc.service.MainServiceRepository
-import com.example.saybettereducator.utils.webrtc.webrtcClient.WebRTCClient
+import com.example.saybettereducator.data.service.MainService
+import com.example.saybettereducator.data.repository.MainServiceRepository
+import com.example.saybettereducator.data.api.helper.WebRTCClient
 import dagger.hilt.android.AndroidEntryPoint
 import org.webrtc.SurfaceViewRenderer
 import javax.inject.Inject

--- a/app/src/main/java/com/example/saybettereducator/ui/intent/VideoCallIntent.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/intent/VideoCallIntent.kt
@@ -1,0 +1,6 @@
+package com.example.saybettereducator.ui.intent
+
+sealed class VideoCallIntent {
+    object OnRemoteViewReady: VideoCallIntent()
+    object SetupView: VideoCallIntent()
+}

--- a/app/src/main/java/com/example/saybettereducator/ui/model/VideoCallState.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/model/VideoCallState.kt
@@ -1,0 +1,7 @@
+package com.example.saybettereducator.ui.model
+
+data class VideoCallState(
+    val isPeerConnected: Boolean = false,
+    val isCaller: Boolean = true,
+    var target: String? = null
+)

--- a/app/src/main/java/com/example/saybettereducator/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/navigation/AppNavHost.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import com.example.saybettereducator.ui.view.screen.CalendarScreen
+import com.example.saybettereducator.ui.view.CalendarScreen
 import com.example.saybettereducator.ui.view.HomeScreen
 import com.example.saybettereducator.ui.view.LearnerScreen
 import com.example.saybettereducator.ui.view.SolutionScreen
@@ -51,7 +51,7 @@ fun AppNavHost(navController: NavHostController, startVideoCall: (String, Boolea
                         launcherMultiplePermissions,
                         onPermissionsGranted = {
                             Log.d("permission", "Permission Granted, Go VideoCall!")
-                            startVideoCall("targetUserId", true)  // 여기서 적절한 값을 전달합니다.
+                            startVideoCall("helloYI", true)  // 여기서 적절한 값을 전달합니다.
                         }
                     )
                 }

--- a/app/src/main/java/com/example/saybettereducator/ui/sideeffect/VideoCallSideEffect.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/sideeffect/VideoCallSideEffect.kt
@@ -1,0 +1,5 @@
+package com.example.saybettereducator.ui.sideeffect
+
+sealed class VideoCallSideEffect {
+    object PeerConnectionSuccess : VideoCallSideEffect()
+}

--- a/app/src/main/java/com/example/saybettereducator/ui/viewmodel/VideoCallViewModel.kt
+++ b/app/src/main/java/com/example/saybettereducator/ui/viewmodel/VideoCallViewModel.kt
@@ -1,0 +1,47 @@
+package com.example.saybettereducator.ui.viewmodel
+
+import android.content.Context
+import android.os.Build
+import android.provider.MediaStore.Video
+import android.util.Log
+import androidx.annotation.RequiresApi
+import com.example.saybettereducator.data.repository.MainRepository
+import com.example.saybettereducator.data.repository.MainServiceRepository
+import com.example.saybettereducator.data.service.MainService
+import com.example.saybettereducator.ui.common.MviViewModel
+import com.example.saybettereducator.ui.intent.VideoCallIntent
+import com.example.saybettereducator.ui.model.VideoCallState
+import com.example.saybettereducator.ui.sideeffect.VideoCallSideEffect
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.webrtc.SurfaceViewRenderer
+import javax.inject.Inject
+
+@HiltViewModel
+class VideoCallViewModel @Inject constructor(
+    private val mainRepository: MainRepository
+): MviViewModel<VideoCallState, VideoCallSideEffect, VideoCallIntent>(VideoCallState()), MainRepository.ConnectionListener {
+
+    override fun handleIntent(intent: VideoCallIntent) {
+        when (intent) {
+            is VideoCallIntent.OnRemoteViewReady -> onRemoteViewReady()
+            is VideoCallIntent.SetupView -> setupView()
+        }
+    }
+
+    init {
+        mainRepository.connectionListener = this
+    }
+
+    private fun setupView() {
+
+    }
+
+    private fun onRemoteViewReady() {
+        updateState { it.copy(isPeerConnected = true) }
+    }
+
+    override fun onPeerConnectionReady() {
+        Log.d("VideoCallViewModel", "Remote View Ready")
+        postSideEffect(VideoCallSideEffect.PeerConnectionSuccess)
+    }
+}

--- a/app/src/main/java/com/example/saybettereducator/utils/webrtc/webrtcClient/WebRTCClient.kt
+++ b/app/src/main/java/com/example/saybettereducator/utils/webrtc/webrtcClient/WebRTCClient.kt
@@ -36,10 +36,24 @@ class WebRTCClient @Inject constructor(
     private val eglBaseContext = EglBase.create().eglBaseContext
     private val peerConnectionFactory by lazy { createPeerConnectionFactory() }
     private var peerConnection: PeerConnection? = null
-    private val iceServer = listOf(
+    private val iceServers = listOf(
+        PeerConnection.IceServer.builder("stun:stun.relay.metered.ca:80").createIceServer(),
+        PeerConnection.IceServer.builder("turn:global.relay.metered.ca:80")
+            .setUsername("3034a2e47ead957a5246ff2d")
+            .setPassword("zAyeHrbfgXr6T/sr")
+            .createIceServer(),
+        PeerConnection.IceServer.builder("turn:global.relay.metered.ca:80?transport=tcp")
+            .setUsername("3034a2e47ead957a5246ff2d")
+            .setPassword("zAyeHrbfgXr6T/sr")
+            .createIceServer(),
+        PeerConnection.IceServer.builder("turn:global.relay.metered.ca:443")
+            .setUsername("3034a2e47ead957a5246ff2d")
+            .setPassword("zAyeHrbfgXr6T/sr")
+            .createIceServer(),
         PeerConnection.IceServer.builder("turns:global.relay.metered.ca:443?transport=tcp")
             .setUsername("3034a2e47ead957a5246ff2d")
-            .setPassword("zAyeHrbfgXr6T/sr").createIceServer()
+            .setPassword("zAyeHrbfgXr6T/sr")
+            .createIceServer()
     )
     private val localVideoSource by lazy { peerConnectionFactory.createVideoSource(false) }
     private val localAudioSource by lazy { peerConnectionFactory.createAudioSource(MediaConstraints()) }
@@ -94,7 +108,7 @@ class WebRTCClient @Inject constructor(
         peerConnection = createPeerConnection(observer)
     }
     private fun createPeerConnection(observer: PeerConnection.Observer): PeerConnection? {
-        return peerConnectionFactory.createPeerConnection(iceServer, observer)
+        return peerConnectionFactory.createPeerConnection(iceServers, observer)
     }
 
     // negotiation section

--- a/app/src/main/java/com/example/saybettereducator/utils/webrtcObserver/MyPeerObserver.kt
+++ b/app/src/main/java/com/example/saybettereducator/utils/webrtcObserver/MyPeerObserver.kt
@@ -1,4 +1,4 @@
-package com.example.saybettereducator.utils.webrtc.webrtcClient
+package com.example.saybettereducator.utils.webrtcObserver
 
 import org.webrtc.DataChannel
 import org.webrtc.IceCandidate

--- a/app/src/main/java/com/example/saybettereducator/utils/webrtcObserver/MySdpObserver.kt
+++ b/app/src/main/java/com/example/saybettereducator/utils/webrtcObserver/MySdpObserver.kt
@@ -1,4 +1,4 @@
-package com.example.saybettereducator.utils.webrtc.webrtcClient
+package com.example.saybettereducator.utils.webrtcObserver
 
 import org.webrtc.SdpObserver
 import org.webrtc.SessionDescription


### PR DESCRIPTION
## 🔎 작업 내용
Utils 패키지에 들어있던 webrtc 파일들을 꺼내서 MVI 패턴에 맞게 마이그레이션 하였습니다.
파일 단위로만 나누었으며 로직 단위로의 마이그레이션 작업은 추후에 진행 예정입니다.
더불어 VideoCall에서 캠 화면을 디자인에 맞게 모양 및 크기/위치를 조절하였습니다.

➕ 이슈 링크
[Android-Educator-APP #17](https://github.com/Say-Better/Android-Educator-APP/issues/17)
